### PR TITLE
Add Stack-ID in generated repository name

### DIFF
--- a/aws-ecr-repository/pom.xml
+++ b/aws-ecr-repository/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ecr</artifactId>
-            <version>2.13.18</version>
+            <version>2.15.33</version>
         </dependency>
     </dependencies>
 

--- a/aws-ecr-repository/pom.xml
+++ b/aws-ecr-repository/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.3</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/CreateHandler.java
+++ b/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/CreateHandler.java
@@ -32,6 +32,7 @@ public class CreateHandler extends BaseHandlerStd {
         if (StringUtils.isNullOrEmpty(model.getRepositoryName())) {
             model.setRepositoryName(
                     IdentifierUtils.generateResourceIdentifier(
+                            request.getStackId(),
                             request.getLogicalResourceIdentifier(),
                             request.getClientRequestToken(),
                             MAX_REPO_NAME_LENGTH


### PR DESCRIPTION
*Description of changes:*
Fixes random repository name generation by making use of Stack-id, when an ecr repository is created in CFN without a RepositoryName.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
