### PR TITLE
increase AWS::ECR::Repository SAM template global memory size

### DIFF
--- a/aws-ecr-repository/template.yml
+++ b/aws-ecr-repository/template.yml
@@ -5,6 +5,7 @@ Description: AWS SAM template for the AWS::ECR::Repository resource type
 Globals:
   Function:
     Timeout: 60  # docker start-up times can be long for SAM CLI
+    MemorySize: 512
 
 Resources:
   TypeFunction:


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* 
Increase memory in AWS::ECR::Repository SAM template to 512. Default of 128 runs into out of memory exceptions with SAM local and contract tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
