### PR TITLE
use common GetRegistryPolicy in BaseHandler; update createHandler to …

### DIFF
--- a/aws-ecr-registrypolicy/src/main/java/software/amazon/ecr/registrypolicy/BaseHandlerStd.java
+++ b/aws-ecr-registrypolicy/src/main/java/software/amazon/ecr/registrypolicy/BaseHandlerStd.java
@@ -2,6 +2,8 @@ package software.amazon.ecr.registrypolicy;
 
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.ecr.model.GetRegistryPolicyRequest;
+import software.amazon.awssdk.services.ecr.model.GetRegistryPolicyResponse;
 import software.amazon.awssdk.services.ecr.model.InvalidParameterException;
 import software.amazon.awssdk.services.ecr.model.RegistryPolicyNotFoundException;
 import software.amazon.awssdk.services.ecr.model.ValidationException;
@@ -33,6 +35,16 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
       logger
     );
   }
+
+ GetRegistryPolicyResponse getRegistryPolicy(GetRegistryPolicyRequest request,
+         ProxyClient<EcrClient> proxyClient,
+         AmazonWebServicesClientProxy proxy,
+         Logger logger) {
+   GetRegistryPolicyResponse response = proxy.injectCredentialsAndInvokeV2(request,
+           proxyClient.client()::getRegistryPolicy);
+   logger.log(ResourceModel.TYPE_NAME + " has successfully been read.");
+   return response;
+ }
 
   protected ProgressEvent<ResourceModel, CallbackContext> handleError(
           final Exception e,

--- a/aws-ecr-registrypolicy/src/main/java/software/amazon/ecr/registrypolicy/ReadHandler.java
+++ b/aws-ecr-registrypolicy/src/main/java/software/amazon/ecr/registrypolicy/ReadHandler.java
@@ -1,7 +1,6 @@
 package software.amazon.ecr.registrypolicy;
 
 import software.amazon.awssdk.services.ecr.EcrClient;
-import software.amazon.awssdk.services.ecr.model.GetRegistryPolicyResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -21,19 +20,10 @@ public class ReadHandler extends BaseHandlerStd {
             .initiate("AWS-ECR-RegistryPolicy::Read", proxyClient, request.getDesiredResourceState(),
                     callbackContext)
             .translateToServiceRequest(Translator::translateToReadRequest)
-            .makeServiceCall((awsRequest, client) -> {
-                GetRegistryPolicyResponse response = proxy.injectCredentialsAndInvokeV2(awsRequest,
-                        proxyClient.client()::getRegistryPolicy);
-                logger.log(ResourceModel.TYPE_NAME + " has successfully been read.");
-                return response;
-            })
+            .makeServiceCall((awsRequest, client) -> getRegistryPolicy(awsRequest, client, proxy, logger))
             .handleError((awsRequest, exception, client, model, context) ->
                     this.handleError(exception, model, context))
-            .done(awsResponse -> {
-                    return ProgressEvent.defaultSuccessHandler(
-                            Translator.translateFromReadResponse(awsResponse));
-            });
+            .done(awsResponse -> ProgressEvent.defaultSuccessHandler(
+                    Translator.translateFromReadResponse(awsResponse)));
         }
-
-
 }

--- a/aws-ecr-registrypolicy/src/main/java/software/amazon/ecr/registrypolicy/UpdateHandler.java
+++ b/aws-ecr-registrypolicy/src/main/java/software/amazon/ecr/registrypolicy/UpdateHandler.java
@@ -57,12 +57,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 proxy.initiate("AWS-ECR-RegistryPolicy::PreUpdateCheck", proxyClient, request.getDesiredResourceState(),
                         progressEvent.getCallbackContext())
                     .translateToServiceRequest(Translator::translateToReadRequest)
-                    .makeServiceCall((awsRequest, client) -> {
-                        GetRegistryPolicyResponse response = proxy.injectCredentialsAndInvokeV2(awsRequest,
-                            proxyClient.client()::getRegistryPolicy);
-                        logger.log(ResourceModel.TYPE_NAME + " has successfully been read.");
-                        return response;
-                    })
+                    .makeServiceCall((awsRequest, client) -> getRegistryPolicy(awsRequest, client, proxy, logger))
                     .handleError((awsRequest, exception, client, model, context) ->
                         this.handleError(exception, model, context))
                     .progress()


### PR DESCRIPTION
…not call ReadHandler for better chain handling

*Issue #, if available:*

*Description of changes:*
* Move common GetRegistryPolicy code to BaseHandler
* Read from CreateHandler directly rather than call ReadHandler for better chain handling/logging

*Testing:*
* mvn package
* cfn test
~~~
handler_create.py::contract_create_delete PASSED                                                                                                                                                                                             [  7%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                            [ 15%]
handler_create.py::contract_create_duplicate SKIPPED (No writable identifiers. Skipping test.)                                                                                                                                               [ 23%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                       [ 30%]
handler_delete.py::contract_delete_read             
PASSED                                                                                                                                                                                               [ 38%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                             [ 46%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                             [ 53%]
handler_delete.py::contract_delete_create SKIPPED (No writable identifiers. Skipping test.)                                                                                                                                                  [ 61%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                          [ 69%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                         [ 76%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                       [ 84%]
handler_update_invalid.py::contract_update_create_only_property SKIPPED (No createOnly Properties. Skipping test.)                                                                                                                           [ 92%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                      [100%]
~~~
* cfn submit
* manual create stack with RegistryPolicy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
