### PR TITLE
Mark additionalProperties as false in the Replication Configuration r…

### DIFF
--- a/aws-ecr-replicationconfiguration/aws-ecr-replicationconfiguration.json
+++ b/aws-ecr-replicationconfiguration/aws-ecr-replicationconfiguration.json
@@ -25,7 +25,8 @@
             "description": "An array of objects representing the details of a replication destination.",
             "required": [
                 "Destinations"
-            ]
+            ],
+            "additionalProperties": false
         },
         "Destinations": {
             "type": "array",
@@ -53,7 +54,8 @@
             "required": [
                 "Region",
                 "RegistryId"
-            ]
+            ],
+            "additionalProperties": false
         },
         "RegistryId": {
             "type": "string",
@@ -77,7 +79,8 @@
             "description": "An object representing the replication configuration for a registry.",
             "required": [
                 "Rules"
-            ]
+            ],
+            "additionalProperties": false
         },
         "RegistryId": {
             "type": "string",


### PR DESCRIPTION
…esource schema

*Description of changes:*

Object types must enforce the property - `additionalProperties` - is used to control the handling properties whose names are not listed in the properties keyword. By default any additional properties are allowed. [[source]](http://json-schema.org/understanding-json-schema/reference/object.html#properties
)

*Testing*

* mvn package
* cfn test
```
handler_create.py::contract_create_delete PASSED                                                                                                                                                                                                                                                                                                                                                                               [  7%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                                                                                                                                                                                                              [ 15%]
handler_create.py::contract_create_duplicate SKIPPED (No writable identifiers. Skipping test.)                                                                                                                                                                                                                                                                                                                                 [ 23%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                                                                                                                                                                                                         [ 30%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                                                                                                                                                                                                                 [ 38%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                                                                                                                                                                                                               [ 46%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                                                                                                                                                                                                               [ 53%]
handler_delete.py::contract_delete_create SKIPPED (No writable identifiers. Skipping test.)                                                                                                                                                                                                                                                                                                                                    [ 61%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                                                                                                                                                                                                            [ 69%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                                                                                                                                                                                                           [ 76%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                                                                                                                                                                                                         [ 84%]
handler_update_invalid.py::contract_update_create_only_property SKIPPED (No createOnly Properties. Skipping test.)                                                                                                                                                                                                                                                                                                             [ 92%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                                                                                                                                                                                                        [100%]

=== 10 passed, 3 skipped, 3 deselected in 520.92s (0:08:40) ===
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
