### PR TITLE
Update the create handler to skip the post check for create RegistryP…

### DIFF
--- a/aws-ecr-registrypolicy/src/test/java/software/amazon/ecr/registrypolicy/CreateHandlerTest.java
+++ b/aws-ecr-registrypolicy/src/test/java/software/amazon/ecr/registrypolicy/CreateHandlerTest.java
@@ -56,11 +56,7 @@ class CreateHandlerTest extends software.amazon.ecr.registrypolicy.AbstractTestB
 
         when(proxyClientMock.client()).thenReturn(ecrMock);
         when(ecrMock.getRegistryPolicy(any(GetRegistryPolicyRequest.class)))
-                .thenThrow(RegistryPolicyNotFoundException.builder().build())
-                .thenReturn(GetRegistryPolicyResponse.builder()
-                        .registryId(TEST_REGISTRY_ID)
-                        .policyText(REGISTRY_POLICY_OUTPUT_TEXT)
-                        .build());
+                .thenThrow(RegistryPolicyNotFoundException.builder().build());
     }
 
     @AfterEach
@@ -85,7 +81,7 @@ class CreateHandlerTest extends software.amazon.ecr.registrypolicy.AbstractTestB
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-        verify(ecrMock, times(2)).getRegistryPolicy(any(GetRegistryPolicyRequest.class));
+        verify(ecrMock, times(1)).getRegistryPolicy(any(GetRegistryPolicyRequest.class));
     }
 
     @Test


### PR DESCRIPTION
…olicy call

**Description of changes:**
Updating the create handler to skip the post creation check. This causes issues if the read call fails after the create, the CFN create will not roll back and delete the already created Registry Policy.

**Testing:**

* mvn package
* cfn test

```
handler_create.py::contract_create_delete PASSED                                                                                                                                                                                          [  7%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                         [ 15%]
handler_create.py::contract_create_duplicate SKIPPED (No writable identifiers. Skipping test.)                                                                                                                                            [ 23%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                    [ 30%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                            [ 38%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                          [ 46%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                          [ 53%]
handler_delete.py::contract_delete_create SKIPPED (No writable identifiers. Skipping test.)                                                                                                                                               [ 61%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                       [ 69%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                      [ 76%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                    [ 84%]
handler_update_invalid.py::contract_update_create_only_property SKIPPED (No createOnly Properties. Skipping test.)                                                                                                                        [ 92%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                   [100%]

================================== 10 passed, 3 skipped, 3 deselected in 452.98s (0:07:32) ==================================
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
