### PR TITLE
Correct the auto-generated stack name format for ECR Repository resource

### DIFF
--- a/aws-ecr-repository/pom.xml
+++ b/aws-ecr-repository/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.2</version>
+            <version>[2.0.0,3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ecr</artifactId>
-            <version>2.13.18</version>
+            <version>2.15.19</version>
         </dependency>
     </dependencies>
 

--- a/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/CreateHandler.java
+++ b/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/CreateHandler.java
@@ -32,6 +32,7 @@ public class CreateHandler extends BaseHandlerStd {
         if (StringUtils.isNullOrEmpty(model.getRepositoryName())) {
             model.setRepositoryName(
                     IdentifierUtils.generateResourceIdentifier(
+                            request.getStackId(),
                             request.getLogicalResourceIdentifier(),
                             request.getClientRequestToken(),
                             MAX_REPO_NAME_LENGTH

--- a/aws-ecr-repository/src/test/java/software/amazon/ecr/repository/CreateHandlerTest.java
+++ b/aws-ecr-repository/src/test/java/software/amazon/ecr/repository/CreateHandlerTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -119,11 +120,19 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_AutogenerateName() {
+        String stackName = "TestStack";
+        String stackId = String.join("/",
+                "arn:aws:cloudformation:us-west-2:123123123123:stack",
+                stackName,
+                UUID.randomUUID().toString());
+        String resourceId = "MyResource";
+
         final ResourceModel model = ResourceModel.builder()
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .logicalResourceIdentifier("MyResource")
+                .stackId(stackId)
+                .logicalResourceIdentifier(resourceId)
                 .clientRequestToken("token")
                 .desiredResourceState(model)
                 .build();
@@ -143,7 +152,8 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
-        assertThat(response.getResourceModel().getRepositoryName()).isNotNull();
+        String repositoryName = String.join("-", stackName, resourceId).toLowerCase();
+        assertThat(response.getResourceModel().getRepositoryName()).startsWith(repositoryName);
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
This change reverts the Repository auto-generated naming convention when user does not provide a Repository name in the CloudFormation template. The name will revert to the format `stackId-resourceId-randomString`.

I had to update the CloudFormation dependency and the corresponding AWS SDK to get the latest changes for auto-generating resource name.

*Testing*  
* mvn package
* CFN test
```
handler_create.py::contract_create_delete PASSED                                                                                                                                                                                          [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                                                                                                         [ 12%]
handler_create.py::contract_create_duplicate PASSED                                                                                                                                                                                       [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                                                                                                    [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                                                                                                    [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                                                                                                            [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                                                                                                            [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                                                                                                          [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                                                                                                          [ 56%]
handler_delete.py::contract_delete_create PASSED                                                                                                                                                                                          [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                                                                                                       [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                                                                                                      [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                                                                                                    [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                                                                                                    [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                                                                                                    [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                                                                                                   [100%]

======================================================================================================== 16 passed in 651.22s (0:10:51) =========================================================================================================

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
