### PR TITLE
Add encryption configuration

### DIFF
--- a/aws-ecr-repository/aws-ecr-repository.json
+++ b/aws-ecr-repository/aws-ecr-repository.json
@@ -55,6 +55,20 @@
         "ScanOnPush": {
             "type": "boolean",
             "description": "The setting that determines whether images are scanned after being pushed to a repository."
+        },
+        "EncryptionType": {
+            "type": "string",
+            "description": "The encryption type to use.",
+            "enum": [
+                "AES256",
+                "KMS"
+            ]
+        },
+        "KmsKey": {
+            "type": "string",
+            "description": "If you use the KMS encryption type, specify the CMK to use for encryption. The alias, key ID, or full ARN of the CMK can be specified. The key must exist in the same Region as the repository. If no key is specified, the default AWS managed CMK for Amazon ECR will be used.",
+            "minLength": 1,
+            "maxLength": 2048
         }
     },
     "properties": {
@@ -105,10 +119,29 @@
                 }
             },
             "additionalProperties": false
+        },
+        "EncryptionConfiguration": {
+            "type": "object",
+            "description": "The encryption configuration for the repository. This determines how the contents of your repository are encrypted at rest.\n\nBy default, when no encryption configuration is set or the AES256 encryption type is used, Amazon ECR uses server-side encryption with Amazon S3-managed encryption keys which encrypts your data at rest using an AES-256 encryption algorithm. This does not require any action on your part.\n\nFor more information, see https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html",
+            "properties": {
+                "EncryptionType": {
+                    "$ref": "#/definitions/EncryptionType"
+                },
+                "KmsKey": {
+                    "$ref": "#/definitions/KmsKey"
+                }
+            },
+            "required": [
+                "EncryptionType"
+            ],
+            "additionalProperties": false
         }
     },
     "createOnlyProperties": [
-        "/properties/RepositoryName"
+        "/properties/RepositoryName",
+        "/properties/EncryptionConfiguration",
+        "/properties/EncryptionConfiguration/EncryptionType",
+        "/properties/EncryptionConfiguration/KmsKey"
     ],
     "readOnlyProperties": [
         "/properties/Arn"
@@ -122,7 +155,10 @@
                 "ecr:CreateRepository",
                 "ecr:PutLifecyclePolicy",
                 "ecr:SetRepositoryPolicy",
-                "ecr:TagResource"
+                "ecr:TagResource",
+                "kms:DescribeKey",
+                "kms:CreateGrant",
+                "kms:RetireGrant"
             ]
         },
         "read": {
@@ -142,12 +178,16 @@
                 "ecr:DeleteLifecyclePolicy",
                 "ecr:DeleteRepositoryPolicy",
                 "ecr:PutImageScanningConfiguration",
-                "ecr:PutImageTagMutability"
+                "ecr:PutImageTagMutability",
+                "kms:DescribeKey",
+                "kms:CreateGrant",
+                "kms:RetireGrant"
             ]
         },
         "delete": {
             "permissions": [
-                "ecr:DeleteRepository"
+                "ecr:DeleteRepository",
+                "kms:RetireGrant"
             ]
         },
         "list": {

--- a/aws-ecr-repository/docs/README.md
+++ b/aws-ecr-repository/docs/README.md
@@ -68,7 +68,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### RepositoryPolicyText
 
-The JSON repository policy text to apply to the repository. For more information, see https://docs.aws.amazon.com/AmazonECR/latest/userguide/RepositoryPolicyExamples.html in the Amazon Elastic Container Registry User Guide. 
+The JSON repository policy text to apply to the repository. For more information, see https://docs.aws.amazon.com/AmazonECR/latest/userguide/RepositoryPolicyExamples.html in the Amazon Elastic Container Registry User Guide.
 
 _Required_: No
 
@@ -137,4 +137,3 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### Arn
 
 Returns the <code>Arn</code> value.
-

--- a/aws-ecr-repository/docs/README.md
+++ b/aws-ecr-repository/docs/README.md
@@ -17,7 +17,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#repositorypolicytext" title="RepositoryPolicyText">RepositoryPolicyText</a>" : <i>Map, String</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>,
         "<a href="#imagetagmutability" title="ImageTagMutability">ImageTagMutability</a>" : <i>String</i>,
-        "<a href="#imagescanningconfiguration" title="ImageScanningConfiguration">ImageScanningConfiguration</a>" : <i><a href="imagescanningconfiguration.md">ImageScanningConfiguration</a></i>
+        "<a href="#imagescanningconfiguration" title="ImageScanningConfiguration">ImageScanningConfiguration</a>" : <i><a href="imagescanningconfiguration.md">ImageScanningConfiguration</a></i>,
+        "<a href="#encryptionconfiguration" title="EncryptionConfiguration">EncryptionConfiguration</a>" : <i><a href="encryptionconfiguration.md">EncryptionConfiguration</a></i>
     }
 }
 </pre>
@@ -34,6 +35,7 @@ Properties:
       - <a href="tag.md">Tag</a></i>
     <a href="#imagetagmutability" title="ImageTagMutability">ImageTagMutability</a>: <i>String</i>
     <a href="#imagescanningconfiguration" title="ImageScanningConfiguration">ImageScanningConfiguration</a>: <i><a href="imagescanningconfiguration.md">ImageScanningConfiguration</a></i>
+    <a href="#encryptionconfiguration" title="EncryptionConfiguration">EncryptionConfiguration</a>: <i><a href="encryptionconfiguration.md">EncryptionConfiguration</a></i>
 </pre>
 
 ## Properties
@@ -66,7 +68,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### RepositoryPolicyText
 
-The JSON repository policy text to apply to the repository. For more information, see https://docs.aws.amazon.com/AmazonECR/latest/userguide/RepositoryPolicyExamples.html in the Amazon Elastic Container Registry User Guide.
+The JSON repository policy text to apply to the repository. For more information, see https://docs.aws.amazon.com/AmazonECR/latest/userguide/RepositoryPolicyExamples.html in the Amazon Elastic Container Registry User Guide. 
 
 _Required_: No
 
@@ -106,6 +108,20 @@ _Type_: <a href="imagescanningconfiguration.md">ImageScanningConfiguration</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+#### EncryptionConfiguration
+
+The encryption configuration for the repository. This determines how the contents of your repository are encrypted at rest.
+
+By default, when no encryption configuration is set or the AES256 encryption type is used, Amazon ECR uses server-side encryption with Amazon S3-managed encryption keys which encrypts your data at rest using an AES-256 encryption algorithm. This does not require any action on your part.
+
+For more information, see https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html
+
+_Required_: No
+
+_Type_: <a href="encryptionconfiguration.md">EncryptionConfiguration</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
 ## Return Values
 
 ### Ref
@@ -121,3 +137,4 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 #### Arn
 
 Returns the <code>Arn</code> value.
+

--- a/aws-ecr-repository/docs/encryptionconfiguration.md
+++ b/aws-ecr-repository/docs/encryptionconfiguration.md
@@ -53,4 +53,3 @@ _Minimum_: <code>1</code>
 _Maximum_: <code>2048</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
-

--- a/aws-ecr-repository/docs/encryptionconfiguration.md
+++ b/aws-ecr-repository/docs/encryptionconfiguration.md
@@ -1,0 +1,56 @@
+# AWS::ECR::Repository EncryptionConfiguration
+
+The encryption configuration for the repository. This determines how the contents of your repository are encrypted at rest.
+
+By default, when no encryption configuration is set or the AES256 encryption type is used, Amazon ECR uses server-side encryption with Amazon S3-managed encryption keys which encrypts your data at rest using an AES-256 encryption algorithm. This does not require any action on your part.
+
+For more information, see https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#encryptiontype" title="EncryptionType">EncryptionType</a>" : <i>String</i>,
+    "<a href="#kmskey" title="KmsKey">KmsKey</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#encryptiontype" title="EncryptionType">EncryptionType</a>: <i>String</i>
+<a href="#kmskey" title="KmsKey">KmsKey</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### EncryptionType
+
+The encryption type to use.
+
+_Required_: Yes
+
+_Type_: String
+
+_Allowed Values_: <code>AES256</code> | <code>KMS</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### KmsKey
+
+If you use the KMS encryption type, specify the CMK to use for encryption. The alias, key ID, or full ARN of the CMK can be specified. The key must exist in the same Region as the repository. If no key is specified, the default AWS managed CMK for Amazon ECR will be used.
+
+_Required_: No
+
+_Type_: String
+
+_Minimum_: <code>1</code>
+
+_Maximum_: <code>2048</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+

--- a/aws-ecr-repository/inputs/inputs_1_create.json
+++ b/aws-ecr-repository/inputs/inputs_1_create.json
@@ -4,5 +4,8 @@
     "ImageTagMutability": "MUTABLE",
     "ImageScanningConfiguration": {
         "ScanOnPush": false
+    },
+    "EncryptionConfiguration": {
+        "EncryptionType": "AES256"
     }
 }

--- a/aws-ecr-repository/inputs/inputs_1_invalid.json
+++ b/aws-ecr-repository/inputs/inputs_1_invalid.json
@@ -13,5 +13,8 @@
             }
         ]
     },
+    "EncryptionConfiguration": {
+        "EncryptionType": "INVALID"
+    },
     "ImageTagMutability": "INVALID"
 }

--- a/aws-ecr-repository/inputs/inputs_1_update.json
+++ b/aws-ecr-repository/inputs/inputs_1_update.json
@@ -4,5 +4,8 @@
     "ImageTagMutability": "MUTABLE",
     "ImageScanningConfiguration": {
         "ScanOnPush": true
+    },
+    "EncryptionConfiguration": {
+        "EncryptionType": "AES256"
     }
 }

--- a/aws-ecr-repository/resource-role.yaml
+++ b/aws-ecr-repository/resource-role.yaml
@@ -37,6 +37,9 @@ Resources:
                 - "ecr:SetRepositoryPolicy"
                 - "ecr:TagResource"
                 - "ecr:UntagResource"
+                - "kms:CreateGrant"
+                - "kms:DescribeKey"
+                - "kms:RetireGrant"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/CreateHandler.java
+++ b/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/CreateHandler.java
@@ -1,6 +1,7 @@
 package software.amazon.ecr.repository;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.ecr.model.KmsException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -50,6 +51,13 @@ public class CreateHandler extends BaseHandlerStd {
             logger.log(String.format("%s [%s] Created Successfully", ResourceModel.TYPE_NAME, model.getRepositoryName()));
         } catch (RepositoryAlreadyExistsException e) {
             throw new ResourceAlreadyExistsException(ResourceModel.TYPE_NAME, model.getRepositoryName());
+        } catch (KmsException e) {
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .resourceModel(model)
+                    .status(OperationStatus.FAILED)
+                    .errorCode(HandlerErrorCode.GeneralServiceException)
+                    .message(e.getMessage())
+                    .build();
         }
 
         try {

--- a/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/ReadHandler.java
+++ b/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/ReadHandler.java
@@ -113,6 +113,16 @@ public class ReadHandler extends BaseHandlerStd {
             logger.log(String.format("AccessDenied error: %s for Repository: %s", e.getMessage(), repo.toString()));
         }
 
+        EncryptionConfiguration encryptionConfiguration = null;
+        if (repo.encryptionConfiguration() != null) {
+            encryptionConfiguration = EncryptionConfiguration.builder()
+                    .encryptionType(repo.encryptionConfiguration().encryptionTypeAsString())
+                    .build();
+            if (repo.encryptionConfiguration().kmsKey() != null) {
+                encryptionConfiguration.setKmsKey(repo.encryptionConfiguration().kmsKey());
+            }
+        }
+
         return ResourceModel.builder()
                 .repositoryName(repositoryName)
                 .lifecyclePolicy(lifecyclePolicy)
@@ -121,6 +131,7 @@ public class ReadHandler extends BaseHandlerStd {
                 .arn(arn)
                 .imageScanningConfiguration(ImageScanningConfiguration.builder().scanOnPush(repo.imageScanningConfiguration().scanOnPush()).build())
                 .imageTagMutability(repo.imageTagMutability().toString())
+                .encryptionConfiguration(encryptionConfiguration)
                 .build();
     }
 }

--- a/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/Translator.java
+++ b/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/Translator.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.services.ecr.model.DeleteLifecyclePolicyRequest;
 import software.amazon.awssdk.services.ecr.model.DeleteRepositoryPolicyRequest;
 import software.amazon.awssdk.services.ecr.model.DeleteRepositoryRequest;
 import software.amazon.awssdk.services.ecr.model.DescribeRepositoriesRequest;
+import software.amazon.awssdk.services.ecr.model.EncryptionConfiguration;
 import software.amazon.awssdk.services.ecr.model.GetLifecyclePolicyRequest;
 import software.amazon.awssdk.services.ecr.model.GetRepositoryPolicyRequest;
 import software.amazon.awssdk.services.ecr.model.ImageScanningConfiguration;
@@ -44,6 +45,15 @@ public class Translator {
 
         if (model.getImageTagMutability() != null) {
             createRepositoryRequest.imageTagMutability(model.getImageTagMutability());
+        }
+
+        if (model.getEncryptionConfiguration() != null) {
+            EncryptionConfiguration.Builder encryptionConfigurationBuilder = EncryptionConfiguration.builder()
+                    .encryptionType(model.getEncryptionConfiguration().getEncryptionType());
+            if (model.getEncryptionConfiguration().getKmsKey() != null) {
+                encryptionConfigurationBuilder.kmsKey(model.getEncryptionConfiguration().getKmsKey());
+            }
+            createRepositoryRequest.encryptionConfiguration(encryptionConfigurationBuilder.build());
         }
 
         return createRepositoryRequest.build();

--- a/aws-ecr-repository/src/test/java/software/amazon/ecr/repository/ReadHandlerTest.java
+++ b/aws-ecr-repository/src/test/java/software/amazon/ecr/repository/ReadHandlerTest.java
@@ -3,6 +3,8 @@ package software.amazon.ecr.repository;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.ecr.model.EcrException;
+import software.amazon.awssdk.services.ecr.model.EncryptionConfiguration;
+import software.amazon.awssdk.services.ecr.model.EncryptionType;
 import software.amazon.awssdk.services.ecr.model.ImageScanningConfiguration;
 import software.amazon.awssdk.services.ecr.model.ImageTagMutability;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -60,6 +62,7 @@ class ReadHandlerTest extends AbstractTestBase {
             .repositoryArn("arn")
             .imageScanningConfiguration(ImageScanningConfiguration.builder().scanOnPush(true).build())
             .imageTagMutability(ImageTagMutability.MUTABLE)
+            .encryptionConfiguration(EncryptionConfiguration.builder().encryptionType(EncryptionType.AES256).build())
             .build();
 
     private final DescribeRepositoriesResponse describeRepositoriesResponse = DescribeRepositoriesResponse.builder()
@@ -121,6 +124,7 @@ class ReadHandlerTest extends AbstractTestBase {
                 .arn("arn")
                 .imageTagMutability("MUTABLE")
                 .imageScanningConfiguration(software.amazon.ecr.repository.ImageScanningConfiguration.builder().scanOnPush(true).build())
+                .encryptionConfiguration(software.amazon.ecr.repository.EncryptionConfiguration.builder().encryptionType("AES256").build())
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
@@ -171,6 +175,7 @@ class ReadHandlerTest extends AbstractTestBase {
                 .arn("arn")
                 .imageTagMutability("MUTABLE")
                 .imageScanningConfiguration(software.amazon.ecr.repository.ImageScanningConfiguration.builder().scanOnPush(true).build())
+                .encryptionConfiguration(software.amazon.ecr.repository.EncryptionConfiguration.builder().encryptionType("AES256").build())
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
@@ -239,6 +244,7 @@ class ReadHandlerTest extends AbstractTestBase {
                 .arn("arn")
                 .imageTagMutability("MUTABLE")
                 .imageScanningConfiguration(software.amazon.ecr.repository.ImageScanningConfiguration.builder().scanOnPush(true).build())
+                .encryptionConfiguration(software.amazon.ecr.repository.EncryptionConfiguration.builder().encryptionType("AES256").build())
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
@@ -291,6 +297,7 @@ class ReadHandlerTest extends AbstractTestBase {
             .arn("arn")
             .imageTagMutability("MUTABLE")
             .imageScanningConfiguration(software.amazon.ecr.repository.ImageScanningConfiguration.builder().scanOnPush(true).build())
+            .encryptionConfiguration(software.amazon.ecr.repository.EncryptionConfiguration.builder().encryptionType("AES256").build())
             .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response =


### PR DESCRIPTION
*Issue #, if available:*
#15

*Description of changes:*
* Added createOnly EncryptionConfiguration property definition in schema
* Modified CRUD operations for the Repository resource
* Added unit tests for the CRUD operations

_Example Updated Repository Schema_
```
"Resources": {
    "ECRR2N7BK": {
        "Type": "AWS::ECR::Repository",
        "Properties": {
            "EncryptionConfiguration": {
                "EncryptionType": "KMS",
                "KmsKey": "arn:aws:kms:us-east-2:12345678910:key/resourceid"
             }
         }
     }
}
```

*Testing*
- mvn package
- cfn test
- cfn submit
  - Create Repository resource with CMK
  - Update above resource to AES encryption
  - Update above resource to KMS default encryption (not CMK)
  - Delete the resource above

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
