### PR TITLE
update cloudformation plugin dependency

### DIFF
--- a/aws-ecr-registrypolicy/pom.xml
+++ b/aws-ecr-registrypolicy/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.3</version>
+            <version>[2.0.0,3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Started running into `mvn package` errors

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project aws-ecr-registrypolicy-handler: Compilation failure: Compilation failure:...
```

Updating version of aws-cloudformation-rpdk-java-plugin dependency fixed this. This mimics version already in place for replication configuration: https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-ecr/blob/master/aws-ecr-replicationconfiguration/pom.xml#L26

* Testing * 
`mvn package`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
