### PR TITLE
add support for replicationConfiguration list handler

### DIFF
--- a/aws-ecr-replicationconfiguration/aws-ecr-replicationconfiguration.json
+++ b/aws-ecr-replicationconfiguration/aws-ecr-replicationconfiguration.json
@@ -114,6 +114,11 @@
                 "ecr:PutReplicationConfiguration",
                 "iam:CreateServiceLinkedRole"
             ]
+        },
+        "list": {
+            "permissions": [
+                "ecr:DescribeRegistry"
+            ]
         }
     }
 }

--- a/aws-ecr-replicationconfiguration/src/main/java/software/amazon/ecr/replicationconfiguration/ListHandler.java
+++ b/aws-ecr-replicationconfiguration/src/main/java/software/amazon/ecr/replicationconfiguration/ListHandler.java
@@ -1,6 +1,8 @@
 package software.amazon.ecr.replicationconfiguration;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.ecr.model.DescribeRegistryResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -8,6 +10,11 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 public class ListHandler extends BaseHandlerStd {
 
@@ -19,10 +26,35 @@ public class ListHandler extends BaseHandlerStd {
         final ProxyClient<EcrClient> proxyClient,
         final Logger logger) {
 
-        return ProgressEvent.<ResourceModel, CallbackContext> builder()
-                .status(OperationStatus.FAILED)
-                .errorCode(HandlerErrorCode.InvalidRequest)
-                .message("List operation is not supported.")
+        final EcrClient client = proxyClient.client();
+
+        DescribeRegistryResponse response;
+
+        try {
+            response = describeRegistryResource(proxy, client);
+            logger.log(String.format("%s [%s] List Read Successful", ResourceModel.TYPE_NAME, response.replicationConfiguration()));
+        } catch (AwsServiceException e) {
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .status(OperationStatus.FAILED)
+                    .resourceModels(emptyList())
+                    .errorCode(HandlerErrorCode.GeneralServiceException)
+                    .message(e.getMessage())
+                    .build();
+        }
+
+        List<ResourceModel> models;
+        if (hasExistingResource(response)) {
+            ResourceModel returnModel = Response.generateResourceModel(request.getAwsAccountId(), response);
+            models = singletonList(returnModel);
+        } else {
+            // If no resource exists then return success with empty list.
+            models = emptyList();
+        }
+
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModels(models)
+                .status(OperationStatus.SUCCESS)
+                .nextToken(null)
                 .build();
     }
 }

--- a/aws-ecr-replicationconfiguration/src/test/java/software/amazon/ecr/replicationconfiguration/ListHandlerTest.java
+++ b/aws-ecr-replicationconfiguration/src/test/java/software/amazon/ecr/replicationconfiguration/ListHandlerTest.java
@@ -1,13 +1,14 @@
 package software.amazon.ecr.replicationconfiguration;
 
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.ecr.EcrClient;
 import software.amazon.awssdk.services.ecr.model.DescribeRegistryRequest;
+import software.amazon.awssdk.services.ecr.model.ValidationException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -15,15 +16,12 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class ListHandlerTest extends AbstractTestBase {
+class ListHandlerTest extends AbstractTestBase {
 
     @Mock
     private AmazonWebServicesClientProxy proxy;
@@ -38,30 +36,76 @@ public class ListHandlerTest extends AbstractTestBase {
 
     @BeforeEach
     public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        handler = new ListHandler();
-        ecr = mock(EcrClient.class);
         proxyEcrClient = MOCK_PROXY(proxy, ecr);
+        handler = new ListHandler();
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
-        // Setup
-        // Generate test request
+    void handleRequest_SimpleSuccess() {
+        doReturn(TestSdkResponseHelper.oneDestinationDescribeRegistryResponse())
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(DescribeRegistryRequest.class), any());
+
         final ResourceHandlerRequest<ResourceModel> request =
-                TestHelper.generateRequest(TestHelper.singleDestination());
+                TestHelper.generateRequestWithPrimaryId(TestHelper.singleDestination());
 
         // Request
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, new CallbackContext(), proxyEcrClient, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, new CallbackContext(), proxyEcrClient, logger);
+
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(response).isNotNull();
+        softly.assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        softly.assertThat(response.getCallbackDelaySeconds()).isZero();
+        softly.assertThat(response.getResourceModel()).isNull();
+        softly.assertThat(response.getResourceModels()).isNotNull();
+        softly.assertThat(response.getResourceModels().get(0)).isEqualTo(request.getDesiredResourceState());
+        softly.assertAll();
+    }
+
+    @Test
+    void handleRequest_NoExistingResourceReturnsSuccessWithEmptyList() {
+        doReturn(TestSdkResponseHelper.emptyDescribeRegistryResponse())
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(DescribeRegistryRequest.class), any());
+
+        final ResourceHandlerRequest<ResourceModel> request =
+                TestHelper.generateRequest(TestHelper.multipleDestinations());
+
+        // Request
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, new CallbackContext(), proxyEcrClient, logger);
+
+        // Validation
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(response).isNotNull();
+        softly.assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        softly.assertThat(response.getCallbackDelaySeconds()).isZero();
+        softly.assertThat(response.getResourceModel()).isNull();
+        softly.assertThat(response.getResourceModels()).isEmpty();
+        softly.assertAll();
+    }
+
+    @Test
+    void handleRequest_ValidationExceptionReturnsFailedEvent() {
+        when(proxy.injectCredentialsAndInvokeV2(any(DescribeRegistryRequest.class), any()))
+                .thenThrow(ValidationException.builder().build());
+
+        final ResourceHandlerRequest<ResourceModel> request =
+                TestHelper.generateRequest(TestHelper.multipleDestinations());
 
 
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackDelaySeconds()).isZero();
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isEqualTo("List operation is not supported.");
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
-        verifyNoInteractions(ecr);
+        // Request
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, new CallbackContext(), proxyEcrClient, logger);
+
+        // Validation
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(response).isNotNull();
+        softly.assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        softly.assertThat(response.getResourceModel()).isNull();
+        softly.assertThat(response.getResourceModels()).isEmpty();
+        softly.assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.GeneralServiceException);
+        softly.assertAll();
     }
 }

--- a/aws-ecr-replicationconfiguration/src/test/java/software/amazon/ecr/replicationconfiguration/ReadHandlerTest.java
+++ b/aws-ecr-replicationconfiguration/src/test/java/software/amazon/ecr/replicationconfiguration/ReadHandlerTest.java
@@ -44,7 +44,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
+    void handleRequest_SimpleSuccess() {
         // Setup
         // Mock DescribeRegistryRequest call
         doReturn(TestSdkResponseHelper.oneDestinationDescribeRegistryResponse())
@@ -71,7 +71,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_NoExistingResourceResponse() {
+    void handleRequest_NoExistingResourceResponse() {
         // Setup
         // Mock DescribeRegistryRequest call
         doReturn(TestSdkResponseHelper.emptyDescribeRegistryResponse())
@@ -98,7 +98,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_GeneralException() {
+    void handleRequest_GeneralException() {
         // Setup
         // Mock DescribeRegistryRequest call
         doThrow(AwsServiceException.class)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add support for replication configuration list handler

*Testing*
mvn package, cfn test, cfn submit

```
handler_create.py::contract_create_delete PASSED    [  7%]
handler_create.py::contract_create_duplicate SKIPPED (No writable identifiers. Skipping test.)  [ 14%]
handler_create.py::contract_create_read_success PASSED   [ 21%]
handler_create.py::contract_create_list_success PASSED  [ 28%]
handler_delete.py::contract_delete_read PASSED  [ 35%]
handler_delete.py::contract_delete_list PASSED  [ 42%]
handler_delete.py::contract_delete_update PASSED [ 50%]
handler_delete.py::contract_delete_delete PASSED  [ 57%]
handler_delete.py::contract_delete_create SKIPPED (No writable identifiers. Skipping test.)  [ 64%]
handler_misc.py::contract_check_asserts_work PASSED  [ 71%]
handler_read.py::contract_read_without_create PASSED  [ 78%]
handler_update.py::contract_update_read_success PASSED  [ 85%]
handler_update.py::contract_update_list_success PASSED [ 92%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED  [100%]

=== 12 passed, 2 skipped in 596.57s (0:09:56) ===
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
