### PR TITLE
add EmptyOnDelete to support force delete on repository resource dele…

### DIFF
--- a/aws-ecr-repository/aws-ecr-repository.json
+++ b/aws-ecr-repository/aws-ecr-repository.json
@@ -95,9 +95,16 @@
             "description": "If you use the KMS encryption type, specify the CMK to use for encryption. The alias, key ID, or full ARN of the CMK can be specified. The key must exist in the same Region as the repository. If no key is specified, the default AWS managed CMK for Amazon ECR will be used.",
             "minLength": 1,
             "maxLength": 2048
+        },
+        "EmptyOnDelete" : {
+            "type": "boolean",
+            "description": "If true, deleting the repository force deletes the contents of the repository. Without a force delete, you can only delete empty repositories."
         }
     },
     "properties": {
+        "EmptyOnDelete" : {
+            "$ref": "#/definitions/EmptyOnDelete"
+        },
         "LifecyclePolicy": {
             "$ref": "#/definitions/LifecyclePolicy"
         },
@@ -155,6 +162,9 @@
     "readOnlyProperties": [
         "/properties/Arn",
         "/properties/RepositoryUri"
+    ],
+    "writeOnlyProperties": [
+        "/properties/EmptyOnDelete"
     ],
     "primaryIdentifier": [
         "/properties/RepositoryName"

--- a/aws-ecr-repository/contract-tests-artifacts/inputs_1.json
+++ b/aws-ecr-repository/contract-tests-artifacts/inputs_1.json
@@ -1,6 +1,6 @@
 {
     "CreateInputs": {
-        "RepositoryName": "my-testing-inputs-repository-test",
+        "RepositoryName": "contract-test-inputs-repository",
         "Tags": [
             {
                 "Key": "Env",
@@ -30,7 +30,8 @@
         },
         "LifecyclePolicy": {
             "LifecyclePolicyText": "{\"rules\":[{\"rulePriority\":1,\"description\":\"Keep only one untagged image, expire all others\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"imageCountMoreThan\",\"countNumber\":1},\"action\":{\"type\":\"expire\"}}]}"
-        }
+        },
+        "EmptyOnDelete": false
     },
 
     "PatchInputs": [

--- a/aws-ecr-repository/docs/README.md
+++ b/aws-ecr-repository/docs/README.md
@@ -12,6 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "AWS::ECR::Repository",
     "Properties" : {
+        "<a href="#emptyondelete" title="EmptyOnDelete">EmptyOnDelete</a>" : <i>Boolean</i>,
         "<a href="#lifecyclepolicy" title="LifecyclePolicy">LifecyclePolicy</a>" : <i><a href="lifecyclepolicy.md">LifecyclePolicy</a></i>,
         "<a href="#repositoryname" title="RepositoryName">RepositoryName</a>" : <i>String</i>,
         "<a href="#repositorypolicytext" title="RepositoryPolicyText">RepositoryPolicyText</a>" : <i>Map, String</i>,
@@ -28,6 +29,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: AWS::ECR::Repository
 Properties:
+    <a href="#emptyondelete" title="EmptyOnDelete">EmptyOnDelete</a>: <i>Boolean</i>
     <a href="#lifecyclepolicy" title="LifecyclePolicy">LifecyclePolicy</a>: <i><a href="lifecyclepolicy.md">LifecyclePolicy</a></i>
     <a href="#repositoryname" title="RepositoryName">RepositoryName</a>: <i>String</i>
     <a href="#repositorypolicytext" title="RepositoryPolicyText">RepositoryPolicyText</a>: <i>Map, String</i>
@@ -39,6 +41,16 @@ Properties:
 </pre>
 
 ## Properties
+
+#### EmptyOnDelete
+
+If true, deleting the repository force deletes the contents of the repository. Without a force delete, you can only delete empty repositories.
+
+_Required_: No
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### LifecyclePolicy
 

--- a/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/Translator.java
+++ b/aws-ecr-repository/src/main/java/software/amazon/ecr/repository/Translator.java
@@ -32,7 +32,7 @@ public class Translator {
     public static final ObjectMapper MAPPER = new ObjectMapper();
 
     static CreateRepositoryRequest createRepositoryRequest(final ResourceModel model,
-                                                           final Map<String, String> tags) {
+            final Map<String, String> tags) {
 
         CreateRepositoryRequest.Builder createRepositoryRequest = CreateRepositoryRequest.builder()
                 .repositoryName(model.getRepositoryName())
@@ -98,9 +98,14 @@ public class Translator {
     }
 
     static DeleteRepositoryRequest deleteRepositoryRequest(final ResourceModel model) {
-        return DeleteRepositoryRequest.builder()
-                .repositoryName(model.getRepositoryName())
-                .build();
+        DeleteRepositoryRequest.Builder requestBuilder = DeleteRepositoryRequest.builder()
+                .repositoryName(model.getRepositoryName());
+
+        if  (model.getEmptyOnDelete() != null) {
+            requestBuilder.force(model.getEmptyOnDelete());
+        }
+
+        return requestBuilder.build();
     }
 
     static TagResourceRequest tagResourceRequest(final List<Tag> tags, final String arn) {
@@ -161,7 +166,7 @@ public class Translator {
     }
 
     static PutImageTagMutabilityRequest putImageTagMutabilityRequest(final ResourceModel model,
-                                                                     final String registryId) {
+            final String registryId) {
         return PutImageTagMutabilityRequest.builder()
                 .registryId(registryId)
                 .repositoryName(model.getRepositoryName())
@@ -170,7 +175,7 @@ public class Translator {
     }
 
     static PutImageScanningConfigurationRequest putImageScanningConfigurationRequest(final ResourceModel model,
-                                                                                     final String registryId) {
+            final String registryId) {
         ImageScanningConfiguration sdkImageScanningConfiguration = ImageScanningConfiguration.builder()
                 .scanOnPush(model.getImageScanningConfiguration().getScanOnPush()).build();
 

--- a/aws-ecr-repository/src/test/java/software/amazon/ecr/repository/DeleteHandlerTest.java
+++ b/aws-ecr-repository/src/test/java/software/amazon/ecr/repository/DeleteHandlerTest.java
@@ -49,7 +49,7 @@ class DeleteHandlerTest extends AbstractTestBase {
     @Test
     void handleRequest_SimpleSuccess() {
         final ProgressEvent<ResourceModel, CallbackContext> response
-            = handler.handleRequest(proxy, request, new CallbackContext(), proxyEcrClient, logger);
+                = handler.handleRequest(proxy, request, new CallbackContext(), proxyEcrClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -69,5 +69,28 @@ class DeleteHandlerTest extends AbstractTestBase {
 
         assertThatThrownBy(() -> handler.handleRequest(proxy, request, context, proxyEcrClient, logger))
                 .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void handleRequest_SuccessWithForceDelete() {
+        model = ResourceModel.builder()
+                .repositoryName("repo")
+                .emptyOnDelete(true)
+                .build();
+
+        request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, new CallbackContext(), proxyEcrClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isZero();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
     }
 }


### PR DESCRIPTION
*Description of changes:*

Add EmptyOnDelete property to Repository resource schema to support the `--force` flag in the DeleteRepository API.

Example template:
```
AWSTemplateFormatVersion: 2010-09-09
Resources:
  repo:
    Type: AWS::ECR::Repository
    Properties:
      RepositoryName: test-empty-on-delete
      EmptyOnDelete: true
```

*Testing*
`mvn package`,  contract tests, manual testing with local custom resource

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
